### PR TITLE
adds ability to switch between configuration profiles

### DIFF
--- a/src/wowman_comrades/core.cljs
+++ b/src/wowman_comrades/core.cljs
@@ -32,18 +32,18 @@
 (def state (atom -state-template))
 
 (def profiles
-  {:default {:description "the configuration you when visiting the page for the first time"
+  {:default {:description "standard configuration, good for everybody"
              :selected-fields {:ads "no" :eula "no" :maintained "yes" :source-available "yes"}}
    
-   :no-selections {:description "all selectable fields are unselected"
-                   :selected-fields (zipmap (:selectable-fields -state-template) (repeat unselected))}
+   :unfiltered {:description "no filtering, ordered by 'maintained', then by 'name'"
+                :selected-fields (zipmap (:selectable-fields -state-template) (repeat unselected))}
 
-   :simple {:description "simple view for simple folk"
-            :field-order [:project :windows :mac]
-            :selected-fields {:maintained "yes"
-                              :windows "yes*"
-                              :retail "yes" :classic "yes"
-                              :ui "GUI"}}
+   :simplistic {:description "simple view for simple folk"
+                :field-order [:project :windows :mac]
+                :selected-fields {:maintained "yes"
+                                  :windows "yes*"
+                                  :retail "yes" :classic "yes"
+                                  :ui "GUI"}}
 
    :linux {:description "good choices for Linux users"
            :field-order [:project :retail :classic :ui :f-oss :source-available :ads :eula :language]
@@ -65,7 +65,7 @@
                                :windows "yes"
                                :retail "yes" :classic "yes"}}
    
-   :perfect {:description "Torkus' perfect addon manager (doesn't exist)"
+   :perfect {:description "the perfect addon manager (doesn't exist)"
              :selected-fields {:maintained "yes"
                                :windows "yes" :mac "yes" :linux "yes"
                                :ui "GUI"

--- a/src/wowman_comrades/core.cljs
+++ b/src/wowman_comrades/core.cljs
@@ -15,16 +15,16 @@
 
 (def -state-template
   {;; fields are displayed in the order they are read in by default
-   ;; this doubles as a means to hide fields
+   ;; this doubles as a means to show/hide fields
    :field-order -field-order
 
    ;; fields that can be selected
    :selectable-fields [:maintained :linux :mac :windows :ui :retail :classic :f-oss :source-available :ads :eula :language]
 
-   ;; name and description of selected configuration
+   ;; map of :name and :description for selected preset
    :profile nil
    
-   ;; default selections for fields that can be selected
+   ;; selections for fields that can be selected
    :selected-fields {}
 
    :csv-data nil})
@@ -140,8 +140,7 @@
   [user-params & {:keys [deepmerge?]}]
   (let [;; only fields in the 'field' namespace
         user-params (kv-filter #(= "field" (namespace %1)) user-params)
-        user-params (kv-map #(vector (-> %1 name keyword) (or %2 "")) user-params)
-        ]
+        user-params (kv-map #(vector (-> %1 name keyword) (or %2 "")) user-params)]
     (when-not (empty? user-params)
       (if deepmerge?
         ;; recursive merge of changes, may cause weirdness
@@ -164,7 +163,7 @@
 
 (defn handle-user-params
   "handles the tricky business of merging multiple types of supported filtering.
-  :field/names can be passed with values as well as :preset/name configuration presets
+  :field/names can be passed with values as well as :preset/name configuration presets.
   configuration presets are applied first, and then field values over it.
 
   for example: ?preset/name=unfiltered&field/language=Go
@@ -196,7 +195,7 @@
                    :field-order new-field-order
 
                    ;; configuration profiles are merged over the top of this
-                   ;; ensures changes don't accumulate in weird ways
+                   ;; to ensure changes do not accumulate in weird ways
                    :safe-state {:field-order new-field-order
                                 :selected-fields (:selected-fields -state-template)}
                    }]

--- a/src/wowman_comrades/core.cljs
+++ b/src/wowman_comrades/core.cljs
@@ -172,7 +172,7 @@
   'default' preset is used, which would hide addons that are not maintained and don't
   support classic."
   [user-params]
-  (let [user-params (spy (parse-user-params))
+  (let [user-params (parse-user-params)
         preset (->> user-params keys (some #{:preset/name}) (get user-params) keyword)]
     
     (when (get profiles preset)

--- a/src/wowman_comrades/core.cljs
+++ b/src/wowman_comrades/core.cljs
@@ -35,15 +35,17 @@
   {:default {:description "some basic filtering, good for everybody"
              :selected-fields {:maintained "yes" :classic "yes"}}
    
-   :unfiltered {:description "no filtering, ordered by 'maintained', then by 'name'"
+   :unfiltered {:description "no filtering, ordered by 'maintained' and then by 'name'"
                 :selected-fields (zipmap (:selectable-fields -state-template) (repeat unselected))}
 
-   :simplistic {:description "simple view for simple folk"
-                :field-order [:project :windows :mac]
-                :selected-fields {:maintained "yes"
-                                  :windows "yes*"
-                                  :retail "yes" :classic "yes"
-                                  :ui "GUI"}}
+   :snarky {:description [:a {:href "https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam?platform=combined"
+                              :target "_blank"}
+                          "\"statistically, this is probably for you\""]
+            :field-order [:project :windows :retail :classic]
+            :selected-fields {:maintained "yes"
+                              :windows "yes"
+                              :retail "yes" :classic "yes"
+                              :ui "GUI"}}
 
    :linux {:description "good choices for Linux users"
            :field-order [:project :retail :classic :ui :f-oss :source-available :ads :eula :language]
@@ -65,7 +67,7 @@
                                :windows "yes"
                                :retail "yes" :classic "yes"}}
    
-   :perfect {:description "the perfect addon manager (doesn't exist)"
+   :perfect {:description "my perfect addon manager (doesn't exist)"
              :selected-fields {:maintained "yes"
                                :windows "yes" :mac "yes" :linux "yes"
                                :ui "GUI"
@@ -164,7 +166,7 @@
                      (drop-column :name)
                      (drop-column :url))
 
-        new-field-order (into [:project] -field-order)
+        new-field-order (into [:project] (remove #{:name :url} -field-order))
         new-state {:csv-data csv-data
                    :field-order new-field-order
 

--- a/src/wowman_comrades/core.cljs
+++ b/src/wowman_comrades/core.cljs
@@ -32,8 +32,8 @@
 (def state (atom -state-template))
 
 (def profiles
-  {:default {:description "standard configuration, good for everybody"
-             :selected-fields {:ads "no" :eula "no" :maintained "yes" :source-available "yes"}}
+  {:default {:description "some basic filtering, good for everybody"
+             :selected-fields {:maintained "yes" :classic "yes"}}
    
    :unfiltered {:description "no filtering, ordered by 'maintained', then by 'name'"
                 :selected-fields (zipmap (:selectable-fields -state-template) (repeat unselected))}

--- a/src/wowman_comrades/ui.cljs
+++ b/src/wowman_comrades/ui.cljs
@@ -88,10 +88,8 @@
   []
   (let [available-profiles (->> core/profiles keys (map name))
         on-select-callback (fn [ev]
-                             (core/set-profile! (keyword (ev-val ev)))
-                             nil)
-        description (-> @core/state :profile :description)
-        ]
+                             (core/set-profile! (keyword (ev-val ev))))
+        description (-> @core/state :profile :description)]
     [:div
      (dropdown "presets" available-profiles on-select-callback
                :default-value-fn #(-> @core/state :profile :name name))

--- a/src/wowman_comrades/ui.cljs
+++ b/src/wowman_comrades/ui.cljs
@@ -65,9 +65,12 @@
 (rum/defc permalink
   "creates a link to the report as it's currently configured"
   []
-  (let [query-string (mapv (fn [[k v]]
-                             (format "%s=%s" (->> k name (str "field/")) v))
-                           (:selected-fields @core/state :selected-fields))
+  (let [selected-field-list (mapv (fn [[k v]]
+                                    (format "%s=%s" (->> k name (str "field/")) v))
+                                  (:selected-fields @core/state :selected-fields))
+        preset (str "preset/name=" (-> @core/state :profile :name name))
+
+        query-string (into [preset] selected-field-list)
         query-string (clojure.string/join "&" query-string)
 
         abs-url (format "%s//%s%s"

--- a/src/wowman_comrades/ui.cljs
+++ b/src/wowman_comrades/ui.cljs
@@ -1,13 +1,11 @@
 (ns wowman-comrades.ui
   (:require
-   [wowman-comrades.core :as core]
+   [wowman-comrades.core :as core :refer [unselected]]
    [wowman-comrades.utils :as utils :refer [debug info warn error spy kv-map format]]
    [rum.core :as rum]
    ))
 
 (def rum-deref rum/react) ;; just an alias, I find 'react' confusing
-
-(def unselected "")
 
 (rum/defc dropdown
   [name {:keys [label option-list]}]

--- a/src/wowman_comrades/ui.cljs
+++ b/src/wowman_comrades/ui.cljs
@@ -87,12 +87,15 @@
         on-select-callback (fn [ev]
                              (core/set-profile! (keyword (ev-val ev)))
                              nil)
+        description (-> @core/state :profile :description)
         ]
     [:div
      (dropdown "presets" available-profiles on-select-callback
                :default-value-fn #(-> @core/state :profile :name name))
      [:quote
-      (format "\"%s\"" (-> @core/state :profile :description))]]))
+      (if (string? description)
+        (format "\"%s\"" description)
+        description)]]))
 
 (rum/defc csv-body
   [row-list field-list]

--- a/src/wowman_comrades/utils.cljs
+++ b/src/wowman_comrades/utils.cljs
@@ -42,3 +42,20 @@
   (into {} (filter (fn [[k v]]
                      (f k v))
                    coll)))
+
+;; https://stackoverflow.com/questions/27130961/clojure-deep-merge-to-ignore-nil-values
+(defn deep-merge*
+  [& maps]
+  (let [f (fn [old new]
+             (if (and (map? old) (map? new))
+                 (merge-with deep-merge* old new)
+                 new))]
+    (if (every? map? maps)
+      (apply merge-with f maps)
+     (last maps))))
+
+(defn deep-merge
+  [& maps]
+  (let [maps (filter identity maps)]
+    (assert (every? map? maps))
+   (apply merge-with deep-merge* maps)))


### PR DESCRIPTION
* with profiles for linux/mac/windows, default, none-selected and my perfect addon manager (that doesn't exist, yet)
* adds a simple drop down to switch between these configuration presets

todo:
- [x] allow preset to be passed as query parameter, supercedes field filtering if present
- [x] ~de-select preset when further filtering occurs~ decided against it. you can have a preset with further filtering now. it's all preserved in the permalink
- [x] review