### PR TITLE
Add the instawow Mac GUI to the list

### DIFF
--- a/comrades.raw.csv
+++ b/comrades.raw.csv
@@ -47,6 +47,7 @@ Jerry-Ma/wowplug,https://github.com/Jerry-Ma/wowplug,yes,yes*,yes*,yes*,CLI,yes,
 jliddev/WowUp,https://github.com/jliddev/WowUp,yes,no,no,yes*,GUI,yes,yes,yes,yes,no,no,C#,yes,no,yes,no,no
 karolswdev/wow,https://github.com/karolswdev/wow,yes,no,yes*,yes*,CLI,no,yes,no,yes,no,no,C#,no,no,no,no,yes
 layday/instawow,https://github.com/layday/instawow,yes,yes,yes,yes,CLI,yes,yes,yes,yes,no,no,Python,yes,yes,yes,yes^,yes
+layday/instawow,https://github.com/layday/instawow,yes,no,yes,no,GUI,yes,yes,yes,yes,no,no,JavaScript,yes,yes,yes,yes^,yes
 Lund259/WoW-Addon-Manager,https://github.com/Lund259/WoW-Addon-Manager,yes,no,no,yes,GUI,yes,no,yes,yes,no,no,C#,no,no,no,no,no
 Mangmasta/MangManager,https://github.com/Mangmasta/MangManager,yes,yes*,yes*,yes*,CLI,yes,yes,no,yes,no,no,C++,yes,no,no,no,no
 MR2011/wowAddonManager,https://github.com/MR2011/wowAddonManager,yes,yes,no,no,TUI,yes,yes,yes,yes,no,no,Rust,yes,no,no,no,yes


### PR DESCRIPTION
I added it as a separate entry because compatibility
is different and I don't think filtering would work if the
UI field was 'CLI/GUI'.