### PR TITLE
Ajour can drop its Linux asterisk

### DIFF
--- a/comrades.csv
+++ b/comrades.csv
@@ -35,7 +35,7 @@ vargen2/Addon,https://github.com/vargen2/Addon,no,no,no,yes*,GUI,yes,yes,yes,MIT
 AcidWeb/CurseBreaker,https://github.com/AcidWeb/CurseBreaker,yes,yes,yes,yes,TUI,yes,yes,yes,GPL-3.0,yes,no,no,Python,yes,yes,yes,yes*,yes
 antiwinter/wowa,https://github.com/antiwinter/wowa,yes,yes*,yes*,yes*,CLI,yes,yes,yes,MIT,yes,no,no,JavaScript,yes,yes,yes,yes,yes
 camas/grunt,https://github.com/camas/grunt,yes,yes*,no,yes*,CLI,yes,yes,yes,MIT,yes,no,no,Rust,yes,no,no,no,no
-casperstorm/ajour,https://github.com/casperstorm/ajour,yes,yes*,yes,yes,GUI,yes,yes,yes,MIT,yes,no,no,Rust,yes,yes,yes,no,no
+casperstorm/ajour,https://github.com/casperstorm/ajour,yes,yes,yes,yes,GUI,yes,yes,yes,MIT,yes,no,no,Rust,yes,yes,yes,no,no
 ColbyWanShinobi/cullingOfStratholme,https://github.com/ColbyWanShinobi/cullingOfStratholme,yes,yes,no,no,CLI,yes,yes,yes,GPL-2.0,yes,no,no,Shell,yes,yes,no,yes,no
 csmith/wadman,https://github.com/csmith/wadman,yes,no,no,yes*,CLI,yes,no,yes,MIT,yes,no,no,Go,yes,no,no,no,yes
 dark0dave/wow-addon-updater,https://gitlab.com/dark0dave/wow-addon-updater,yes,yes*,yes*,yes*,CLI,yes,yes,yes,GPL-3.0,yes,no,no,Python,yes,yes,yes,yes*,no


### PR DESCRIPTION
[I packaged it on the AUR](https://aur.archlinux.org/packages/ajour)

[Git version also](https://aur.archlinux.org/packages/ajour-git)